### PR TITLE
✨ Add a new optional interface for components to expose a corresponding status condition

### DIFF
--- a/components/ready_status.go
+++ b/components/ready_status.go
@@ -48,6 +48,10 @@ func NewReadyStatusComponent(keys ...string) core.Component {
 	return &readyStatusComponent{keys: keys, readyConditions: readyConditions}
 }
 
+func (comp *readyStatusComponent) GetReadyCondition() string {
+	return "Ready"
+}
+
 func (comp *readyStatusComponent) Reconcile(ctx *core.Context) (core.Result, error) {
 	objConditions, err := core.GetConditionsFor(ctx.Object)
 	if err != nil {

--- a/components/template.go
+++ b/components/template.go
@@ -48,6 +48,10 @@ func NewTemplateComponent(template string, conditionType string) core.Component 
 	return &templateComponent{template: template, conditionType: conditionType}
 }
 
+func (comp *templateComponent) GetReadyCondition() string {
+	return comp.conditionType
+}
+
 func (comp *templateComponent) Setup(ctx *core.Context, bldr *ctrl.Builder) error {
 	// Render with a fake, blank object just to find the object type.
 	obj, err := comp.renderTemplate(ctx, true)
@@ -59,10 +63,6 @@ func (comp *templateComponent) Setup(ctx *core.Context, bldr *ctrl.Builder) erro
 }
 
 func (comp *templateComponent) Reconcile(ctx *core.Context) (core.Result, error) {
-	if comp.conditionType != "" {
-		ctx.Conditions.SetUnknown(comp.conditionType, "Unknown")
-	}
-
 	// Render the object to an Unstructured.
 	obj, err := comp.renderTemplate(ctx, true)
 	if err != nil {

--- a/core/components.go
+++ b/core/components.go
@@ -34,6 +34,10 @@ type FinalizerComponent interface {
 	Finalize(*Context) (Result, bool, error)
 }
 
+type ReadyConditionComponent interface {
+	GetReadyCondition() string
+}
+
 type Result struct {
 	Requeue       bool
 	RequeueAfter  time.Duration


### PR DESCRIPTION
This condition will automatically be set to Unknown at the start of a reconcile, and to an error state with the error message if a reconcile call fails.