### PR TITLE
Surface 'Watches` method to monitor external resources.

### DIFF
--- a/core/reconciler.go
+++ b/core/reconciler.go
@@ -33,7 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // Supporting mocking out functions for testing
@@ -89,6 +91,11 @@ func NewReconciler(mgr ctrl.Manager) *Reconciler {
 func (r *Reconciler) For(apiType client.Object, opts ...builder.ForOption) *Reconciler {
 	r.apiType = apiType
 	r.controllerBuilder = r.controllerBuilder.For(apiType, opts...)
+	return r
+}
+
+func (r *Reconciler) Watches(src source.Source, eventhandler handler.EventHandler, opts ...builder.WatchesOption) *Reconciler {
+	r.controllerBuilder = r.controllerBuilder.Watches(src, eventhandler, opts...)
 	return r
 }
 


### PR DESCRIPTION
Adds a new method `Watches` to `Reconciler` that proxies a call to the underlying `Builder` [Watches](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/builder#Builder.Watches) method. This will allow clients of `controller-utils` to watch externally managed resources (e.g., an external config map used in a template).